### PR TITLE
Updated main folder variables with file name not matching variable name

### DIFF
--- a/fiscalsim_us/variables/gov/states/va/tax/income/va_disability_income_reported_as_wages.py
+++ b/fiscalsim_us/variables/gov/states/va/tax/income/va_disability_income_reported_as_wages.py
@@ -1,7 +1,7 @@
 from fiscalsim_us.model_api import *
 
 
-class disability_income_reported_as_wages(Variable):
+class va_disability_income_reported_as_wages(Variable):
     value_type = float
     entity = TaxUnit
     label = "VA disability income reported as wages - https://www.tax.virginia.gov/sites/default/files/taxforms/individual-income-tax/2021/760-2021.pdf"

--- a/fiscalsim_us/variables/gov/states/va/tax/income/va_fixed_date_conformity_additions .py
+++ b/fiscalsim_us/variables/gov/states/va/tax/income/va_fixed_date_conformity_additions .py
@@ -1,7 +1,7 @@
 from fiscalsim_us.model_api import *
 
 
-class fixed_date_conformity_additions(Variable):
+class va_fixed_date_conformity_additions(Variable):
     value_type = float
     entity = TaxUnit
     label = "Va fixed date conformity additions https://www.tax.virginia.gov/sites/default/files/taxforms/individual-income-tax/2021/schedule-adj-2021.pdf"

--- a/fiscalsim_us/variables/gov/states/va/tax/income/va_fixed_date_conformity_subtractions.py
+++ b/fiscalsim_us/variables/gov/states/va/tax/income/va_fixed_date_conformity_subtractions.py
@@ -1,7 +1,7 @@
 from fiscalsim_us.model_api import *
 
 
-class fixed_date_conformity_subtractions(Variable):
+class va_fixed_date_conformity_subtractions(Variable):
     value_type = float
     entity = TaxUnit
     label = "Va fixed date conformity subtractions https://www.tax.virginia.gov/sites/default/files/taxforms/individual-income-tax/2021/schedule-adj-2021.pdf"

--- a/fiscalsim_us/variables/gov/states/va/tax/income/va_income_from_obligations_fed_exempt.py
+++ b/fiscalsim_us/variables/gov/states/va/tax/income/va_income_from_obligations_fed_exempt.py
@@ -1,7 +1,7 @@
 from fiscalsim_us.model_api import *
 
 
-class income_from_obligations_fed_exempt(Variable):
+class va_income_from_obligations_fed_exempt(Variable):
     value_type = float
     entity = TaxUnit
     label = "VA income from obligations that are federally exempt https://www.tax.virginia.gov/sites/default/files/taxforms/individual-income-tax/2021/schedule-adj-2021.pdf"

--- a/fiscalsim_us/variables/gov/states/va/tax/income/va_income_from_obligations_state_exempt.py
+++ b/fiscalsim_us/variables/gov/states/va/tax/income/va_income_from_obligations_state_exempt.py
@@ -1,7 +1,7 @@
 from fiscalsim_us.model_api import *
 
 
-class income_from_obligations_state_exempt(Variable):
+class va_income_from_obligations_state_exempt(Variable):
     value_type = float
     entity = TaxUnit
     label = "VA income from obligations that are state exempt https://www.tax.virginia.gov/sites/default/files/taxforms/individual-income-tax/2021/schedule-adj-2021.pdf"


### PR DESCRIPTION
- [x] `make format` and `make documentation` has been run. (You may also want to run `make test`.)

This PR updates 5 variable files in the Virginia (VA) folder for which the filename did not match the FiscalSim-US variable name. For example, the file `va_disability_income_reported_as_wages.py` had a variable name `disability_income_reported_as_wages.py`, which was missing the `va_` prefix. This variable was referred to in the model as `va_disability_income_reported_as_wages.py`, which would create an error. This was the case for the other four variables as well.

I don't understand why the `test_microsim.py` test didn't fail when I ran the tests locally. Luckily, it did fail when the GH Actions CI tests ran.

cc: @austinperryfrancis 